### PR TITLE
Fix mistake in part 1 math

### DIFF
--- a/phy293/tuts/tut2.tex
+++ b/phy293/tuts/tut2.tex
@@ -12,7 +12,7 @@
 \begin{enumerate}
     \item We want critical damping, so $2\omega = \gamma$ where $\omega=\sqrt{k/m}$ and $\gamma=b/m$. This gives 
     \begin{equation}
-        4\frac{k}{m} =  \frac{b^2}{m^2} \implies b = 4\sqrt{mk}
+        4\frac{k}{m} =  \frac{b^2}{m^2} \implies b = 2\sqrt{mk}
     \end{equation}
     We can determine the spring constant $k$ by looking at the equilibrium location, which occurs at $mg=k\Delta l \implies k = \frac{mg}{\Delta l}$. This gives 
     \begin{equation}


### PR DESCRIPTION
4 should be inside the square root, which makes it 2 when you take it out, not 4